### PR TITLE
[CI] Shrink Android CPU test artifacts to fix CXX_Func_Tests timeout

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -305,6 +305,28 @@ jobs:
           find ${TBB_INSTALL}/lib -name "*.so*" -type f -exec cp {} ${INSTALL_DIR}/lib/ \; 2>/dev/null || echo "No .so files in TBB_INSTALL/lib"
           cp "${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/${{ env.ANDROID_ABI_CONFIG }}-linux-android/libc++_shared.so" ${INSTALL_DIR}/lib/ || echo "libc++_shared.so not found"
 
+      # The Release build still compiles with -g (NDK default), so the test binaries
+      # (~1.6 GB / ~1 GB) and runtime .so's carry debug symbols that are never used on
+      # the emulator (no backtrace/symbolization step). Strip them to shrink every
+      # download driven by the Build/CXX_*_Tests jobs. --strip-unneeded keeps the
+      # dynamic symbol table required for loading/linking, so test execution is
+      # unchanged. This complements the per-binary artifact split below.
+      - name: Strip debug symbols from test binaries and runtime libraries
+        run: |
+          STRIP="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip"
+          [ -x "$STRIP" ] || STRIP="$(command -v llvm-strip)"
+          echo "Using strip: $STRIP"
+          before=$(du -sh ${INSTALL_TEST_DIR} ${INSTALL_DIR} | awk '{print $1" "$2}')
+          # Test binaries (executables): --strip-all is safe, nothing dlopen's them.
+          find ${INSTALL_TEST_DIR}/bin/intel64/Release -type f \
+            \( -name "ov_cpu_func_tests" -o -name "ov_cpu_unit_tests" \) \
+            -exec "$STRIP" --strip-all {} \;
+          # Runtime shared libraries: keep the dynamic symbol table for loader/linker.
+          find ${INSTALL_DIR}/runtime/lib/intel64 ${INSTALL_DIR}/lib -type f -name "*.so*" \
+            -exec "$STRIP" --strip-unneeded {} \;
+          echo "Size before strip: $before"
+          echo "Size after  strip: $(du -sh ${INSTALL_TEST_DIR} ${INSTALL_DIR} | awk '{print $1" "$2}')"
+
       - name: Pack openvino_package
         run: tar -cvf - * | pigz > ${BUILD_DIR}/openvino_package.tar.gz
         working-directory: ${{ env.INSTALL_DIR }}
@@ -313,11 +335,24 @@ jobs:
         run: tar -cvf - * | pigz > ${BUILD_DIR}/openvino_tests.tar.gz
         working-directory: ${{ env.INSTALL_TEST_DIR }}
 
-      - name: Upload CPU test binaries
+      # Upload each CPU test binary as its own artifact so that the emulator jobs
+      # download only the single binary they actually push to the device, instead
+      # of the whole android_tests/ tree (both binaries + a duplicate install tree
+      # under android_tests/tests + test_model_zoo). The func/unit jobs each push
+      # exactly one of these to the device, so a combined >2 GB artifact made the
+      # "Download CPU test binaries" step alone consume most of the 20-min budget.
+      - name: Upload CPU functional test binary
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ov_cpu_tests_android_${{ matrix.arch }}
-          path: ${{ env.INSTALL_TEST_DIR }}/
+          name: ov_cpu_func_tests_android_${{ matrix.arch }}
+          path: ${{ env.INSTALL_TEST_DIR }}/bin/intel64/Release/ov_cpu_func_tests
+          if-no-files-found: 'error'
+
+      - name: Upload CPU unit test binary
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ov_cpu_unit_tests_android_${{ matrix.arch }}
+          path: ${{ env.INSTALL_TEST_DIR }}/bin/intel64/Release/ov_cpu_unit_tests
           if-no-files-found: 'error'
 
       - name: Upload OpenVINO runtime package (Android)
@@ -360,11 +395,11 @@ jobs:
         uses: ababushk/checkout@dd591a6a2ac25618db4eda86e7e0d938f88cf01b # cherry_pick_retries
         timeout-minutes: 15
 
-      - name: Download CPU test binaries
+      - name: Download CPU unit test binary
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
-          name: ov_cpu_tests_android_x64
-          path: ${{ env.INSTALL_TEST_DIR }}
+          name: ov_cpu_unit_tests_android_x64
+          path: ${{ env.INSTALL_TEST_DIR }}/bin/intel64/Release
 
       - name: Download OpenVINO runtime package (Android)
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
@@ -454,11 +489,11 @@ jobs:
         uses: ababushk/checkout@dd591a6a2ac25618db4eda86e7e0d938f88cf01b # cherry_pick_retries
         timeout-minutes: 15
 
-      - name: Download CPU test binaries
+      - name: Download CPU functional test binary
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
-          name: ov_cpu_tests_android_x64
-          path: ${{ env.INSTALL_TEST_DIR }}
+          name: ov_cpu_func_tests_android_x64
+          path: ${{ env.INSTALL_TEST_DIR }}/bin/intel64/Release
 
       - name: Download OpenVINO runtime package (Android)
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0


### PR DESCRIPTION
## What was done

Reduce the data downloaded by the Android `CXX_Func_Tests` / `CXX_Unit_Tests` jobs so the `Download CPU test binaries` step no longer consumes most of the 20-minute budget.

### 1. Split the test artifact per binary
- Replaced the single `ov_cpu_tests_android_<arch>` artifact (the whole `android_tests/` tree) with two artifacts, each containing exactly one binary:
  - `ov_cpu_func_tests_android_<arch>`
  - `ov_cpu_unit_tests_android_<arch>`
- `CXX_Func_Tests` now downloads only `ov_cpu_func_tests`; `CXX_Unit_Tests` downloads only `ov_cpu_unit_tests`.
- This drops the data each job no longer needs: the duplicate install tree under `android_tests/tests/`, `ov_cpu_unit_tests_vectorized`, `ov_gpu_func_tests`, `ov_lp_transformations_tests`, the `model_hub_tests` Python tree, and `test_model_zoo`.

### 2. Strip debug symbols before packaging
- The Release build still compiles with `-g`, so test binaries and runtime `.so`s carried unused debug symbols.
- Added a `Strip debug symbols` step in the `Build` job:
  - test binaries → `llvm-strip --strip-all`
  - runtime libraries → `llvm-strip --strip-unneeded` (keeps the dynamic symbol table needed for loading/linking)
- Logs artifact size before/after.

### Notes
- No `timeout-minutes` change.
- On-disk paths the emulator scripts expect (`${INSTALL_TEST_DIR}/bin/intel64/Release/ov_cpu_{func,unit}_tests`) are unchanged, so test execution is identical.